### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/com/example/employee/config/SecurityConfig.java
+++ b/src/main/java/com/example/employee/config/SecurityConfig.java
@@ -14,7 +14,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))
             .authorizeHttpRequests(authz -> authz
                 .requestMatchers("/api/employees/**").permitAll()
                 .requestMatchers("/h2-console/**").permitAll()


### PR DESCRIPTION
Potential fix for [https://github.com/manipurir/demo-copilot-dependabot/security/code-scanning/1](https://github.com/manipurir/demo-copilot-dependabot/security/code-scanning/1)

To fix this problem, CSRF protection should be re-enabled by removing the call to `.csrf(AbstractHttpConfigurer::disable)`. By default, Spring Security enables CSRF protection, so removing the explicit disabling will restore safe defaults. To maintain the ability for the H2 console to work (which might require CSRF be ignored for those endpoints or allowed to use frames), we need to customize CSRF configuration so that CSRF is disabled only for the H2 console path (`/h2-console/**`), but enabled elsewhere. This can be done by using `.csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))`. No changes to imports are necessary.

Edit only the `filterChain` method in `src/main/java/com/example/employee/config/SecurityConfig.java`:
- Replace `.csrf(AbstractHttpConfigurer::disable)` with `.csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))` so CSRF is enforced everywhere except for the H2 console.
- No need to add new imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
